### PR TITLE
Add financial data loader and KPI utilities

### DIFF
--- a/examples/quick_check.py
+++ b/examples/quick_check.py
@@ -1,0 +1,28 @@
+"""Quick manual check for KPI computation."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from finance.kpis import compute_kpis
+
+
+def main() -> None:
+    data = compute_kpis("AAPL")
+    fields = [
+        ("rev_cagr_3y", data["growth"].get("rev_cagr_3y")),
+        ("op_margin_ttm", data["profit"].get("op_margin_ttm")),
+        ("roic_ttm", data["quality"].get("roic_ttm")),
+        ("net_debt_ebitda", data["leverage"].get("net_debt_ebitda")),
+        ("current_ratio", data["liquidity"].get("current_ratio")),
+        ("dividend_yield_ttm", data["shareholder"].get("dividend_yield_ttm")),
+        ("total_return_3y", data["performance"].get("total_return_3y")),
+    ]
+    for name, val in fields:
+        print(f"{name:20s}: {val}")
+
+
+if __name__ == "__main__":
+    main()

--- a/finance/__init__.py
+++ b/finance/__init__.py
@@ -1,0 +1,5 @@
+"""Finance analysis utilities."""
+
+from .kpis import compute_kpis
+
+__all__ = ["compute_kpis"]

--- a/finance/kpis.py
+++ b/finance/kpis.py
@@ -1,0 +1,302 @@
+"""Deterministic KPI calculations for financial analysis.
+
+This module loads prices and financial statements via :class:`FinanceLoader`
+then computes a bundle of key performance indicators. All calculations are
+pure Python and tolerate missing data by returning ``None``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .loader import FinanceLoader
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+def _cagr(series: pd.Series, years: int) -> Optional[float]:
+    """Return the compound annual growth rate for ``series`` over ``years``.
+
+    The series must contain at least ``years + 1`` non-null values ordered by
+    time. Returns ``None`` if the calculation is not possible.
+    """
+    series = series.dropna().sort_index()
+    if len(series) < years + 1:
+        return None
+    start = series.iloc[-(years + 1)]
+    end = series.iloc[-1]
+    if start <= 0 or end <= 0:
+        return None
+    return (end / start) ** (1 / years) - 1
+
+
+def _latest(data, key: Optional[str] = None) -> Optional[float]:
+    """Return the latest non-null scalar from ``data``.
+
+    ``data`` may be a Series or DataFrame. If ``key`` is provided for a
+    DataFrame, that column is used.
+    """
+    try:
+        if isinstance(data, pd.DataFrame):
+            if key is None or key not in data.columns:
+                return None
+            series = data[key]
+        else:
+            series = data
+        val = series.dropna().iloc[-1]
+        return float(val)
+    except Exception:
+        return None
+
+
+def _ttm_from_quarterlies(df: pd.DataFrame, cols: List[str]) -> Dict[str, float]:
+    """Return trailing-twelve-month sums for selected columns."""
+    out: Dict[str, float] = {}
+    if df is None or df.empty:
+        return out
+    df = df.sort_index().tail(4)
+    for col in cols:
+        if col in df.columns:
+            val = df[col].dropna().sum()
+            if pd.notna(val):
+                out[col] = float(val)
+    return out
+
+
+def _dividend_yield_ttm(prices: pd.DataFrame) -> Optional[float]:
+    """Compute trailing 12 month dividend yield from ``prices`` if possible."""
+    if "Dividends" not in prices.columns:
+        return None
+    last = prices.index[-1]
+    start = last - pd.Timedelta(days=365)
+    divs = prices["Dividends"][prices.index >= start].sum()
+    close = prices["Adj Close"].iloc[-1]
+    if close and close != 0:
+        return float(divs) / float(close)
+    return None
+
+
+def _total_return(prices: pd.DataFrame, years: int) -> Optional[float]:
+    """Simple total return for ``years`` using adjusted close and dividends."""
+    if prices.empty:
+        return None
+    adj = prices["Adj Close"].dropna().sort_index()
+    end_date = adj.index[-1]
+    start_date = end_date - pd.DateOffset(years=years)
+    adj_since = adj[adj.index >= start_date]
+    if adj_since.empty:
+        return None
+    start_price = adj_since.iloc[0]
+    end_price = adj.iloc[-1]
+    if start_price == 0:
+        return None
+    divs = 0.0
+    if "Dividends" in prices.columns:
+        divs = prices["Dividends"][prices.index >= adj_since.index[0]].sum()
+    return float(end_price + divs) / float(start_price) - 1
+
+
+# ---------------------------------------------------------------------------
+# KPI computation
+
+def compute_kpis(ticker: str, period_years: int = 5, tax_rate_fallback: float = 0.21) -> Dict:
+    """Compute a bundle of KPIs for ``ticker``.
+
+    Parameters
+    ----------
+    ticker:
+        Ticker symbol, e.g. ``"AAPL"`` or ``"SU.TO"``.
+    period_years:
+        Number of years of price history to download.
+    tax_rate_fallback:
+        Used when the effective tax rate cannot be derived from the income
+        statement.
+    """
+
+    loader = FinanceLoader()
+    prices = loader.load_prices(ticker, period_years)
+    stmts = loader.load_statements(ticker)
+    notes: List[str] = []
+
+    as_of = pd.Timestamp.utcnow().date().isoformat()
+    if not prices.empty:
+        as_of = prices.index[-1].tz_convert("UTC").date().isoformat()
+
+    income_a = stmts["income_annual"].sort_index()
+    balance_a = stmts["balance_annual"].sort_index()
+    cash_a = stmts["cashflow_annual"].sort_index()
+    income_q = stmts["income_quarterly"]
+    cash_q = stmts["cashflow_quarterly"]
+
+    ttm_income = _ttm_from_quarterlies(
+        income_q,
+        [
+            "total_revenue",
+            "gross_profit",
+            "operating_income",
+            "net_income",
+            "ebit",
+            "ebitda",
+            "income_tax_expense",
+            "pre_tax_income",
+            "interest_expense",
+        ],
+    )
+    ttm_cash = _ttm_from_quarterlies(cash_q, ["operating_cash_flow", "capital_expenditures"])
+
+    # ---------------------------- Growth
+    rev_series = income_a.get("total_revenue", pd.Series(dtype=float))
+    eps_series = income_a.get("diluted_eps")
+    if eps_series is None or eps_series.dropna().empty:
+        ni = income_a.get("net_income")
+        shares = income_a.get("diluted_shares_outstanding") or income_a.get("diluted_average_shares")
+        if ni is not None and shares is not None:
+            eps_series = ni / shares
+        else:
+            eps_series = pd.Series(dtype=float)
+
+    growth = {
+        "rev_cagr_3y": _cagr(rev_series, 3),
+        "rev_cagr_5y": _cagr(rev_series, 5),
+        "eps_cagr_3y": _cagr(eps_series, 3),
+        "eps_cagr_5y": _cagr(eps_series, 5),
+    }
+
+    # ---------------------------- Profitability
+    revenue = ttm_income.get("total_revenue") or _latest(income_a, "total_revenue")
+    gross_profit = ttm_income.get("gross_profit") or _latest(income_a, "gross_profit")
+    operating_income = ttm_income.get("operating_income") or _latest(income_a, "operating_income")
+    net_income = ttm_income.get("net_income") or _latest(income_a, "net_income")
+
+    ocf = ttm_cash.get("operating_cash_flow") or _latest(cash_a, "operating_cash_flow")
+    capex = ttm_cash.get("capital_expenditures") or _latest(cash_a, "capital_expenditures")
+    fcf = ocf - capex if ocf is not None and capex is not None else None
+
+    def _margin(num, den):
+        return (num / den) if (num is not None and den not in (None, 0)) else None
+
+    profit = {
+        "gross_margin_ttm": _margin(gross_profit, revenue),
+        "op_margin_ttm": _margin(operating_income, revenue),
+        "net_margin_ttm": _margin(net_income, revenue),
+        "fcf_margin_ttm": _margin(fcf, revenue),
+    }
+
+    # ---------------------------- Quality & Efficiency
+    tax_exp = ttm_income.get("income_tax_expense") or _latest(income_a, "income_tax_expense")
+    pre_tax = ttm_income.get("pre_tax_income") or _latest(income_a, "pre_tax_income")
+    if tax_exp is not None and pre_tax not in (None, 0):
+        tax_rate = tax_exp / pre_tax
+    else:
+        tax_rate = tax_rate_fallback
+        notes.append("tax_rate_fallback_used")
+
+    nopat = operating_income * (1 - tax_rate) if operating_income is not None else None
+
+    debt = _latest(balance_a, "total_debt")
+    if debt is None:
+        lt = _latest(balance_a, "long_term_debt")
+        st = _latest(balance_a, "short_long_term_debt")
+        if lt is not None or st is not None:
+            debt = (lt or 0) + (st or 0)
+    equity = _latest(balance_a, "total_stockholder_equity") or _latest(balance_a, "total_equity")
+    cash = _latest(balance_a, "cash_and_cash_equivalents") or _latest(balance_a, "cash")
+    invested_capital: Optional[float] = None
+    if debt is not None and equity is not None and cash is not None:
+        invested_capital = debt + equity - cash
+    else:
+        assets = _latest(balance_a, "total_assets")
+        curr_liab = _latest(balance_a, "total_current_liabilities") or _latest(balance_a, "current_liabilities")
+        if assets is not None and curr_liab is not None and cash is not None:
+            invested_capital = assets - curr_liab - cash
+
+    roic = (nopat / invested_capital) if (nopat is not None and invested_capital not in (None, 0)) else None
+    roe = _margin(net_income, equity)
+    fcf_over_ni = _margin(fcf, net_income)
+
+    quality = {
+        "roic_ttm": roic,
+        "roe_ttm": roe,
+        "fcf_over_ni_ttm": fcf_over_ni,
+    }
+
+    # ---------------------------- Leverage & Solvency
+    net_debt = (debt - cash) if (debt is not None and cash is not None) else None
+    ebitda = ttm_income.get("ebitda") or _latest(income_a, "ebitda")
+    ndebt_ebitda = _margin(net_debt, ebitda) if net_debt is not None else None
+
+    ebit = ttm_income.get("ebit") or _latest(income_a, "ebit") or operating_income
+    interest = ttm_income.get("interest_expense") or _latest(income_a, "interest_expense")
+    interest_cov = (ebit / abs(interest)) if (ebit is not None and interest not in (None, 0)) else None
+
+    leverage = {
+        "net_debt": net_debt,
+        "net_debt_ebitda": ndebt_ebitda,
+        "interest_coverage": interest_cov,
+    }
+
+    # ---------------------------- Liquidity
+    curr_assets = _latest(balance_a, "total_current_assets") or _latest(balance_a, "current_assets")
+    curr_liab = _latest(balance_a, "total_current_liabilities") or _latest(balance_a, "current_liabilities")
+    inventory = _latest(balance_a, "inventory")
+    current_ratio = _margin(curr_assets, curr_liab)
+    quick_ratio = _margin((curr_assets - inventory) if (curr_assets is not None and inventory is not None) else None, curr_liab)
+
+    liquidity = {
+        "current_ratio": current_ratio,
+        "quick_ratio": quick_ratio,
+    }
+
+    # ---------------------------- Shareholder returns
+    dividend_yield = _dividend_yield_ttm(prices) if not prices.empty else None
+    shares_col = None
+    for col in ["diluted_shares_outstanding", "diluted_average_shares"]:
+        if col in income_a.columns:
+            shares_col = col
+            break
+    buyback_yield = None
+    if shares_col:
+        shares = income_a[shares_col].dropna().sort_index()
+        if len(shares) >= 2:
+            last = shares.iloc[-1]
+            prev = shares.iloc[-2]
+            if prev != 0:
+                buyback_yield = -(last - prev) / prev
+    shareholder = {
+        "dividend_yield_ttm": dividend_yield,
+        "buyback_yield": buyback_yield,
+    }
+
+    # ---------------------------- Performance
+    performance = {
+        "total_return_1y": _total_return(prices, 1),
+        "total_return_3y": _total_return(prices, 3),
+        "total_return_5y": _total_return(prices, 5),
+    }
+
+    return {
+        "ticker": ticker.upper(),
+        "as_of": as_of,
+        "growth": growth,
+        "profit": profit,
+        "quality": quality,
+        "leverage": leverage,
+        "liquidity": liquidity,
+        "shareholder": shareholder,
+        "performance": performance,
+        "notes": notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ticker", required=True)
+    ap.add_argument("--years", type=int, default=5)
+    args = ap.parse_args()
+    out = compute_kpis(args.ticker, period_years=args.years)
+    print(json.dumps(out, indent=2, default=lambda x: None))

--- a/finance/loader.py
+++ b/finance/loader.py
@@ -1,0 +1,122 @@
+"""Data loading utilities for financial analysis.
+
+This module fetches price and statement data from Yahoo Finance using
+`yfinance` and caches the raw DataFrames as Parquet files for
+reproducibility.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Callable, Dict
+
+import pandas as pd
+import yfinance as yf
+
+CACHE_DIR = os.getenv("CACHE_DIR", "storage/cache")
+
+
+def _to_snake(name: str) -> str:
+    """Convert CamelCase or spaces to lower snake_case."""
+    name = re.sub("[^0-9a-zA-Z]+", "_", name)
+    name = re.sub("([a-z0-9])([A-Z])", r"\1_\2", name)
+    return name.replace("__", "_").strip("_").lower()
+
+
+def _to_snake_cols(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of *df* with snake_cased columns."""
+    return df.rename(columns={c: _to_snake(str(c)) for c in df.columns})
+
+
+def load_cached_or(fn: Callable[[], pd.DataFrame], path: str) -> pd.DataFrame:
+    """Load a DataFrame from *path* or compute with *fn* and cache."""
+    if os.path.exists(path):
+        try:
+            return pd.read_parquet(path)
+        except Exception:
+            pass
+    df = fn()
+    if df is None:
+        df = pd.DataFrame()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        df.to_parquet(path)
+    except Exception as exc:  # pragma: no cover - caching failure shouldn't stop
+        print(f"warning: could not cache {path}: {exc}")
+    return df
+
+
+class FinanceLoader:
+    """Small abstraction over yfinance with on-disk caching."""
+
+    def __init__(self, cache_dir: str = CACHE_DIR):
+        self.cache_dir = cache_dir
+
+    # ------------------------------------------------------------------ Prices
+    def load_prices(self, ticker: str, period_years: int = 5) -> pd.DataFrame:
+        """Load daily OHLCV prices for *ticker*.
+
+        Data are downloaded from Yahoo Finance for the given period and cached
+        under ``{cache_dir}/{ticker}/prices.parquet``.
+        """
+
+        tdir = os.path.join(self.cache_dir, ticker.upper())
+        path = os.path.join(tdir, "prices.parquet")
+
+        def _download() -> pd.DataFrame:
+            try:
+                df = yf.download(ticker, period=f"{period_years}y", progress=False, actions=True)
+            except Exception as exc:  # pragma: no cover - network errors
+                print(f"warning: failed to download prices for {ticker}: {exc}")
+                return pd.DataFrame()
+            if not df.empty:
+                df.index = pd.to_datetime(df.index).tz_localize("UTC")
+            return df
+
+        df = load_cached_or(_download, path)
+        return df
+
+    # -------------------------------------------------------------- Statements
+    def load_statements(self, ticker: str) -> Dict[str, pd.DataFrame]:
+        """Load financial statements for *ticker*.
+
+        Annual and quarterly income statement, balance sheet and cash flow
+        tables are fetched and cached individually. Missing tables are returned
+        as empty DataFrames.
+        """
+
+        tdir = os.path.join(self.cache_dir, ticker.upper())
+        os.makedirs(tdir, exist_ok=True)
+        tkr = yf.Ticker(ticker)
+
+        def _fetch_attr(attr: str, quarterly: bool) -> pd.DataFrame:
+            try:
+                data = getattr(tkr, attr)
+                df = data.T if hasattr(data, "T") else pd.DataFrame()
+            except Exception:
+                df = pd.DataFrame()
+            if df is None:
+                df = pd.DataFrame()
+            if not df.empty:
+                df = _to_snake_cols(df)
+            if df.empty:
+                kind = "quarterly" if quarterly else "annual"
+                print(f"warning: {ticker} missing {attr} {kind} data")
+            return df
+
+        income_annual = load_cached_or(lambda: _fetch_attr("financials", False), os.path.join(tdir, "income_annual.parquet"))
+        balance_annual = load_cached_or(lambda: _fetch_attr("balance_sheet", False), os.path.join(tdir, "balance_annual.parquet"))
+        cashflow_annual = load_cached_or(lambda: _fetch_attr("cashflow", False), os.path.join(tdir, "cashflow_annual.parquet"))
+
+        income_quarterly = load_cached_or(lambda: _fetch_attr("quarterly_financials", True), os.path.join(tdir, "income_quarterly.parquet"))
+        balance_quarterly = load_cached_or(lambda: _fetch_attr("quarterly_balance_sheet", True), os.path.join(tdir, "balance_quarterly.parquet"))
+        cashflow_quarterly = load_cached_or(lambda: _fetch_attr("quarterly_cashflow", True), os.path.join(tdir, "cashflow_quarterly.parquet"))
+
+        return {
+            "income_annual": income_annual,
+            "balance_annual": balance_annual,
+            "cashflow_annual": cashflow_annual,
+            "income_quarterly": income_quarterly,
+            "balance_quarterly": balance_quarterly,
+            "cashflow_quarterly": cashflow_quarterly,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ numpy
 pypdf
 tqdm
 python-dotenv
+pandas
+yfinance

--- a/tests/test_kpis.py
+++ b/tests/test_kpis.py
@@ -1,0 +1,40 @@
+"""Lightweight tests for KPI computation."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from finance.kpis import compute_kpis
+
+
+def _check_sections(data: dict) -> None:
+    for key in [
+        "growth",
+        "profit",
+        "quality",
+        "leverage",
+        "liquidity",
+        "shareholder",
+        "performance",
+    ]:
+        assert key in data
+        assert isinstance(data[key], dict)
+        for v in data[key].values():
+            assert v is None or isinstance(v, (int, float))
+
+
+def test_aapl_basic() -> None:
+    data = compute_kpis("AAPL")
+    _check_sections(data)
+
+
+def test_canadian_ticker() -> None:
+    data = compute_kpis("SU.TO")
+    _check_sections(data)
+
+
+def test_short_period() -> None:
+    data = compute_kpis("AAPL", period_years=1)
+    _check_sections(data)


### PR DESCRIPTION
## Summary
- add FinanceLoader to download/cached prices and statements via yfinance
- compute deterministic KPI bundle with CLI and helper functions
- provide quick-check example script and basic tests

## Testing
- `python -m finance.kpis --ticker AAPL >/tmp/aapl.json`
- `python examples/quick_check.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a168855880832ab1b200f62445a52f