### PR TITLE
Handle missing Adj Close in KPI calculations

### DIFF
--- a/finance/kpis.py
+++ b/finance/kpis.py
@@ -66,6 +66,14 @@ def _ttm_from_quarterlies(df: pd.DataFrame, cols: List[str]) -> Dict[str, float]
     return out
 
 
+def _close_col(prices: pd.DataFrame) -> Optional[str]:
+    """Return the column name for close prices, adjusted if available."""
+    for col in ("Adj Close", "Close"):
+        if col in prices.columns:
+            return col
+    return None
+
+
 def _dividend_yield_ttm(prices: pd.DataFrame) -> Optional[float]:
     """Compute trailing 12 month dividend yield from ``prices`` if possible."""
     if "Dividends" not in prices.columns:
@@ -73,17 +81,23 @@ def _dividend_yield_ttm(prices: pd.DataFrame) -> Optional[float]:
     last = prices.index[-1]
     start = last - pd.Timedelta(days=365)
     divs = prices["Dividends"][prices.index >= start].sum()
-    close = prices["Adj Close"].iloc[-1]
+    col = _close_col(prices)
+    if col is None:
+        return None
+    close = prices[col].iloc[-1]
     if close and close != 0:
         return float(divs) / float(close)
     return None
 
 
 def _total_return(prices: pd.DataFrame, years: int) -> Optional[float]:
-    """Simple total return for ``years`` using adjusted close and dividends."""
+    """Simple total return for ``years`` using close prices and dividends."""
     if prices.empty:
         return None
-    adj = prices["Adj Close"].dropna().sort_index()
+    col = _close_col(prices)
+    if col is None:
+        return None
+    adj = prices[col].dropna().sort_index()
     end_date = adj.index[-1]
     start_date = end_date - pd.DateOffset(years=years)
     adj_since = adj[adj.index >= start_date]

--- a/tests/test_kpis.py
+++ b/tests/test_kpis.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 import os
 import sys
 
+import pandas as pd
+import pytest
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from finance.kpis import compute_kpis
+from finance.kpis import compute_kpis, _dividend_yield_ttm, _total_return
 
 
 def _check_sections(data: dict) -> None:
@@ -38,3 +41,17 @@ def test_canadian_ticker() -> None:
 def test_short_period() -> None:
     data = compute_kpis("AAPL", period_years=1)
     _check_sections(data)
+
+
+def test_dividend_yield_close_only() -> None:
+    idx = pd.date_range("2023-01-01", periods=3, freq="M")
+    prices = pd.DataFrame({"Close": [100, 101, 102], "Dividends": [0.5, 0.0, 0.0]}, index=idx)
+    dy = _dividend_yield_ttm(prices)
+    assert dy == pytest.approx(0.5 / 102)
+
+
+def test_total_return_close_only() -> None:
+    idx = pd.to_datetime(["2022-01-01", "2023-01-01"])
+    prices = pd.DataFrame({"Close": [100, 110], "Dividends": [0.0, 5.0]}, index=idx)
+    tr = _total_return(prices, years=1)
+    assert tr == pytest.approx(0.15)


### PR DESCRIPTION
## Summary
- handle new yfinance default by selecting an available close column for KPI computations
- avoid KeyError in dividend yield and total return when only `Close` is provided
- add tests covering fallback logic for price columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a172d824a4832a8182dd6d9f6930cc