### PR TITLE
Add decision brief generator and API

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import HTMLResponse, JSONResponse
+import os, shutil, asyncio, subprocess
+
+from generator import generate_decision_brief
+
+app = FastAPI(title="RAG Financial Assistant")
+DATA_DIR = os.getenv("DATA_DIR", "data")
+os.makedirs(DATA_DIR, exist_ok=True)
+
+@app.get("/", response_class=HTMLResponse)
+def home():
+    return """
+    <html><body style="font-family: sans-serif; max-width: 800px; margin: 2rem auto">
+      <h2>RAG Financial Assistant</h2>
+      <form action="/upload" method="post" enctype="multipart/form-data">
+        <p><b>Upload Annual Report (PDF)</b></p>
+        <input type="file" name="file" accept="application/pdf"/>
+        <button type="submit">Upload & Rebuild Index</button>
+      </form>
+      <hr/>
+      <form action="/analyze" method="post">
+        <p><b>Ticker</b> <input name="ticker" placeholder="AAPL or SU.TO"/></p>
+        <button type="submit">Run Analysis</button>
+      </form>
+    </body></html>"""
+
+@app.post("/upload")
+async def upload(file: UploadFile = File(...)):
+    # Save PDF
+    dest = os.path.join(DATA_DIR, file.filename)
+    with open(dest, "wb") as f:
+        shutil.copyfileobj(file.file, f)
+    # Rebuild index by calling ingest.py as a subprocess (simple/robust)
+    subprocess.run(["python", "ingest.py"], check=True)
+    return {"status": "ok", "saved": file.filename}
+
+@app.post("/analyze")
+async def analyze(ticker: str = Form(...)):
+    try:
+        result = generate_decision_brief(ticker)
+        return JSONResponse(result)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/generator.py
+++ b/generator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+import os, json
+from typing import List, Dict
+
+from finance.kpis import compute_kpis
+from retrieval import Retriever
+from models import get_generator
+from prompts import DEFAULT_QUERIES, build_prompt
+
+def collect_excerpts(r: Retriever, queries=DEFAULT_QUERIES, k_final=6) -> List[Dict]:
+    out = []
+    for q, section in queries:
+        hits = r.retrieve(q, section=section, k_final=min(3, k_final))
+        out.extend(hits)
+    # de-duplicate by (file,page,text[:60])
+    seen, uniq = set(), []
+    for h in out:
+        key = (h["meta"].get("file"), h["meta"].get("page"), h["text"][:60])
+        if key not in seen:
+            seen.add(key); uniq.append(h)
+    return uniq[:k_final]
+
+def generate_decision_brief(ticker: str, years: int = 5, k_final: int = 6) -> Dict:
+    kpis = compute_kpis(ticker, period_years=years)
+    try:
+        r = Retriever()
+        ctx = collect_excerpts(r, k_final=k_final)
+    except FileNotFoundError:
+        ctx = []
+
+    prompt = build_prompt(ticker.upper(), kpis, ctx)
+    pipe = get_generator()
+    # keep it deterministic & concise
+    out = pipe(prompt, max_new_tokens=450, do_sample=False)[0]["generated_text"]
+    # take only the model's answer portion
+    answer = out.split("Answer:", 1)[-1].strip()
+
+    citemap = [{"id": f"R{i+1}", "file": c["meta"]["file"], "page": c["meta"]["page"], "section": c["meta"]["section"]} for i, c in enumerate(ctx)]
+    return {
+      "ticker": kpis.get("ticker", ticker.upper()),
+      "as_of": kpis.get("as_of"),
+      "kpis": kpis,
+      "narrative": answer,
+      "citations": citemap
+    }
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ticker", required=True)
+    ap.add_argument("--years", type=int, default=5)
+    ap.add_argument("--k", type=int, default=6)
+    args = ap.parse_args()
+    print(json.dumps(generate_decision_brief(args.ticker, args.years, args.k), indent=2))

--- a/models.py
+++ b/models.py
@@ -41,3 +41,18 @@ def get_reranker() -> CrossEncoder:
         name = os.getenv("RERANKER_NAME", "BAAI/bge-reranker-large")
         _reranker = CrossEncoder(name)
     return _reranker
+from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
+
+_gen_pipe = None
+def get_generator():
+    """
+    Return a local HF text-generation pipeline (default: Qwen2.5-3B-Instruct).
+    Override via HF_MODEL env. Intended for short analytical summaries (300–500 tokens).
+    """
+    global _gen_pipe
+    if _gen_pipe is None:
+        name = os.getenv("HF_MODEL", "Qwen/Qwen2.5-3B-Instruct")
+        tok = AutoTokenizer.from_pretrained(name)
+        model = AutoModelForCausalLM.from_pretrained(name, device_map="auto")
+        _gen_pipe = pipeline("text-generation", model=model, tokenizer=tok)
+    return _gen_pipe

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,42 @@
+DEFAULT_QUERIES = [
+    ("Key risks last fiscal year", "Risk Factors"),
+    ("Liquidity and capital resources", "MD&A"),
+    ("Debt maturities, interest, covenants", "MD&A"),
+    ("Capital allocation, dividends, buybacks, capex", "MD&A"),
+]
+
+SYSTEM_INSTRUCT = (
+    "You are a cautious equity research assistant. Use ONLY the provided metrics and excerpts. "
+    "Cite excerpts using [R#]. If unknown, say so. Be concise and neutral."
+)
+
+def build_prompt(tkr: str, kpi_json: dict, excerpts: list[dict]) -> str:
+    """
+    Compose a single prompt: header + compact KPIs + numbered excerpts with [R#] ids + tasks.
+    Each excerpt dict: {text, meta:{file,page,section}}
+    """
+    lines = [
+        SYSTEM_INSTRUCT,
+        "",
+        f"Company: {tkr}",
+        "",
+        "Metrics (deterministic JSON):",
+        str(kpi_json),
+        "",
+        "Context excerpts:",
+    ]
+    for i, ex in enumerate(excerpts, 1):
+        m = ex["meta"]
+        cite = f"[R{i}] (Source: {m.get('file')} p.{m.get('page')} • {m.get('section')})"
+        txt = ex["text"].replace("\n", " ")
+        lines.append(f"{cite}\n{txt}\n")
+    lines += [
+        "Tasks:",
+        "1) Operational performance (growth, margins, ROIC).",
+        "2) Liquidity/solvency; call out refinancing/debt risks.",
+        "3) Cash generation & capital allocation (dividends/buybacks/capex).",
+        "4) 3–5 key risks, faithful to excerpts, each with [R#].",
+        "5) One balanced watchlist paragraph (bull vs bear).",
+        "Answer:",
+    ]
+    return "\n".join(lines)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,10 @@ python-dotenv
 pandas
 yfinance
 rank-bm25
+
+transformers
+accelerate
+safetensors
+fastapi
+uvicorn[standard]
+python-multipart


### PR DESCRIPTION
## Summary
- add text-generation loader and prompts for decision briefs
- implement generator orchestrating KPIs, retrieval, and LLM
- expose FastAPI service for PDF ingest and ticker analysis

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `HF_MODEL=dummy_model python generator.py --ticker AAPL`
- `HF_MODEL=dummy_model uvicorn app:app --port 8000 --reload & curl -X POST -F ticker=AAPL http://localhost:8000/analyze`

------
https://chatgpt.com/codex/tasks/task_e_68a27175d35c832ab666cc66e41cfe43